### PR TITLE
renamed in changelog and updated release version and date

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,4 @@
-turnkey-emby-mediaserver-14.0 (1) turnkey; urgency=low
+turnkey-mediaserver-14.1 (1) turnkey; urgency=low
 
   * Initial public release of TurnKey Media Server
 
@@ -13,4 +13,4 @@ turnkey-emby-mediaserver-14.0 (1) turnkey; urgency=low
   * Note: Please refer to turnkey-core's changelog for changes common to all
     appliances. Here we only describe changes specific to this appliance.
 
- -- Jonathan Struebel <jonathan.struebel@gmail.com>  Wed, 25 Nov 2015 21:06:30 +0700
+ -- Jonathan Struebel <jonathan.struebel@gmail.com>  Tue, 16 Feb 2016 21:06:30 +0700


### PR DESCRIPTION
I hope changing the changelog entry date is not too dodgey but as it didn't make it into v14.0 and there has been other bits and pieces done since then it seemed silly to have the date so long ago...
