### PR TITLE
Updating MediaServer with TKLDev v17.0

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,5 +1,13 @@
 turnkey-mediaserver-17.0 (1) turnkey; urgency=low
 
+  * Update JellyFin code to install dependency without error code
+
+  * Note: Please refer to turnkey-core's 17.0 changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Mattie Darden <mattie@turnkeylinux.org>  Thur, 01 Sep 2022 09:59:24 -0400
+turnkey-mediaserver-17.0 (1) turnkey; urgency=low
+
   * Update Jellyfin to latest upstream stable (from jellyfin repos) - v10.7.7.
 
   * Add "Logout" button to WebDAV via custom code addition - closes #989.

--- a/changelog
+++ b/changelog
@@ -1,8 +1,8 @@
 turnkey-mediaserver-17.1 (1) turnkey; urgency=low
 
-  * Update JellyFin to latest upstream stable(from jellyfin repos) v10.7.7.
+  * Update JellyFin to latest upstream stable(from jellyfin repos) v10.7.7. [Zhenya Hvorostian <zhenya@turnkeylinux.org>]
 
-  * Add "logout" button to WebDAV via custom code addition - closes #989.
+  * Add "logout" button to WebDAV via custom code addition - closes #989. [Zhenya Hvorostian <zhenya@turnkeylinux.org>]
 
   * Update JellyFin code to install dependency without error code using apt-get.
 

--- a/changelog
+++ b/changelog
@@ -1,21 +1,15 @@
-turnkey-mediaserver-17.0 (1) turnkey; urgency=low
+turnkey-mediaserver-17.1 (1) turnkey; urgency=low
 
-  * Update JellyFin code to install dependency without error code
+  * Update JellyFin to latest upstream stable(from jellyfin repos) v10.7.7.
 
-  * Note: Please refer to turnkey-core's 17.0 changelog for changes common to all
-    appliances. Here we only describe changes specific to this appliance.
+  * Add "logout" button to WebDAV via custom code addition - closes #989.
 
- -- Mattie Darden <mattie@turnkeylinux.org>  Thur, 01 Sep 2022 09:59:24 -0400
-turnkey-mediaserver-17.0 (1) turnkey; urgency=low
-
-  * Update Jellyfin to latest upstream stable (from jellyfin repos) - v10.7.7.
-
-  * Add "Logout" button to WebDAV via custom code addition - closes #989.
+  * Update JellyFin code to install dependency without error code using apt-get.
 
   * Note: Please refer to turnkey-core's 17.0 changelog for changes common to all
     appliances. Here we only describe changes specific to this appliance.
 
- -- Zhenya Hvorostian <zhenya@turnkeylinux.org>  Tue, 08 Feb 2022 19:24:24 +0300
+ -- Mattie Darden  <mattie@turnkeylinux.org>  Thu, 01 Sep 2022 23:35:47 +0000
 
 turnkey-mediaserver-16.1 (1) turnkey; urgency=low
 

--- a/conf.d/main
+++ b/conf.d/main
@@ -9,7 +9,7 @@ curl -sS $APT_GPG_URL | apt-key --keyring /usr/share/keyrings/jellyfin.gpg add -
 
 apt-get update
 apt-get -y install jellyfin
-apt install -y jellyfin-ffmpeg5
+apt-get -y install jellyfin-ffmpeg5
 
 # Rename the file server for WebDAVCGI
 CONF=/var/www/webdavcgi/webdav.conf

--- a/conf.d/main
+++ b/conf.d/main
@@ -8,7 +8,8 @@ APT_GPG_URL=https://repo.jellyfin.org/debian/jellyfin_team.gpg.key
 curl -sS $APT_GPG_URL | apt-key --keyring /usr/share/keyrings/jellyfin.gpg add -
 
 apt-get update
-apt-get -y install jellyfin jellyfin-ffmpeg
+apt-get -y install jellyfin
+apt install -y jellyfin-ffmpeg5
 
 # Rename the file server for WebDAVCGI
 CONF=/var/www/webdavcgi/webdav.conf


### PR DESCRIPTION
After code review, received error code about jelly fin dependency install. Changed file in conf.d/main to remove error code while still receiving successful mediaserver.iso image. PR changes have been documented in change log and tested. 